### PR TITLE
Require openjdk >= 17

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -96,7 +96,7 @@ outputs:
       run:
         - pyarrow =*=*{{ build_ext }}
         - python
-        - openjdk >=11
+        - openjdk >=17
         - zlib
         - tbb
         - folly >=2022.11.07.00  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "0.9.0" %}  # PEP 386
 
-{% set number = "2" %}
+{% set number = "3" %}
 {% set cuda_enabled = cuda_compiler_version is not undefined and cuda_compiler_version == '11.0' %}
 {% set build_ext = "cuda" if cuda_enabled else "cpu" %}
 {% set build_string = "h{}_{}".format(PKG_HASH, number) %}


### PR DESCRIPTION
We use JNI to interface with Java libraries in our codebase. In openjdk 11, JNI does not clean up properly and results in a crash when the application terminates. We investigated and determined an update to openjdk 17 is the best resolution.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
